### PR TITLE
Fix termsyn font tar error and alacritty deprecated opacity setting

### DIFF
--- a/alacritty.nix
+++ b/alacritty.nix
@@ -22,7 +22,7 @@
       size = 10.0;
     };
 
-    background_opacity = 0.65;
+    window.opacity = 0.65;
 
     shell = {
       program = "${pkgs.fish}/bin/fish";

--- a/kilin/termsyn.nix
+++ b/kilin/termsyn.nix
@@ -8,10 +8,11 @@ in
     url = "mirror://sourceforge/project/termsyn/termsyn-${version}.tar.gz";
     
     postFetch = ''
+      mkdir termsyn-${version}
+      mv $out/* termsyn-${version}
       mkdir -p $out/share/fonts/locale
-      tar -xf $downloadedFile -C $out
-      mv $out/termsyn-${version}/* $out/share/fonts/locale
-      rm -r $out/termsyn-${version} $out/share/fonts/locale/README.termsyn
+      mv termsyn-${version}/* $out/share/fonts/locale
+      rm -rf termsyn-${version} $out/share/fonts/locale/README.termsyn
     '';
     
     sha256 = "1j6hn3nlfb83pvjw9h8r8mi4bhx8b0s3zrcqzj8pa631iv08vif6";


### PR DESCRIPTION
Hello there,

When trying to build the kilin configuration using `home-manager 22.05` and `nix (Nix) 2.8.1` I encountered a strange error.
```bash
error: builder for '/nix/store/6znzhy4z8lvk3gpyfg2qwvk2yv84vkcp-termsyn-1.8.6.drv' failed with exit code 2;
       last 9 log lines:
       >
       > trying https://downloads.sourceforge.net/project/termsyn/termsyn-1.8.6.tar.gz
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       > 100   339  100   339    0     0    417      0 --:--:-- --:--:-- --:--:--   417
       > 100  163k  100  163k    0     0  87226      0  0:00:01  0:00:01 --:--:--  233k
       > unpacking source archive /build/termsyn-1.8.6.tar.gz
       > tar: /build/file: Cannot open: No such file or directory
       > tar: Error is not recoverable: exiting now
```
After some reviewing it seems that the line `tar -xf $downloadedFile -C $out` is the one causing a problem. In [this](https://ryantm.github.io/nixpkgs/builders/fetchers/) documentation about fetchers, it's says :
> fetchzip on the other hand will decompress the archive for you, making files and directories directly accessible in the future.

Which mean that the tar.gz downloaded is already extracted in `$out`. I removed the line causing the error and moved all the decompressed files to a temporary location before applying the initial setup logic.

---

For alacritty the `background_opacity` is deprecated and need to be replaced by `window.opacity` to remove the annoying error message when starting a terminal